### PR TITLE
Fix issue with reduce no longer performing magic

### DIFF
--- a/lib/Text/Wrap/Wrap.rakumod
+++ b/lib/Text/Wrap/Wrap.rakumod
@@ -11,7 +11,10 @@ sub wrap-paragraph(Str $_, :$max-len, :$prefix) {
     my (&len, $paragraph-prefix) = (&display-length, $prefix || ~$<prefix>);
     my $line-len = len $prefix;
 
-    sub wrap-words-to-lines(@lines, $text ($word, $ws='')) {
+    multi sub wrap-words-to-lines(@lines) {
+        wrap-words-to-lines(@lines, ("",))
+    }
+    multi sub wrap-words-to-lines(@lines, $text ($word, $ws='')) {
         my $prefix = ~($paragraph-prefix ~~ /\n*<(\V*)>/);
 
         my @next-lines = gather if $line-len+len($word) ≤ $max-len {


### PR DESCRIPTION
The "operator" of a &reduce must be able to accept 1 and 0 arg cases as well.  The "sub wrap-words-to-lines" wasn't able to do that, and started failing in tests since

  https://github.com/rakudo/rakudo/commit/9bcb01e966d2b29c103faa32ba880e2ab444648c

which showed up in https://github.com/rakudo/rakudo/issues/5783